### PR TITLE
Add TimeBaseEntity and Payment entity with related enums

### DIFF
--- a/payment-service/src/main/java/com/ydmins/metapay/payment_service/PaymentServiceApplication.java
+++ b/payment-service/src/main/java/com/ydmins/metapay/payment_service/PaymentServiceApplication.java
@@ -2,8 +2,10 @@ package com.ydmins.metapay.payment_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class PaymentServiceApplication {
 
 	public static void main(String[] args) {

--- a/payment-service/src/main/java/com/ydmins/metapay/payment_service/domain/common/TimeBaseEntity.java
+++ b/payment-service/src/main/java/com/ydmins/metapay/payment_service/domain/common/TimeBaseEntity.java
@@ -1,0 +1,20 @@
+package com.ydmins.metapay.payment_service.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class TimeBaseEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/payment-service/src/main/java/com/ydmins/metapay/payment_service/domain/payment/Payment.java
+++ b/payment-service/src/main/java/com/ydmins/metapay/payment_service/domain/payment/Payment.java
@@ -1,0 +1,25 @@
+package com.ydmins.metapay.payment_service.domain.payment;
+
+import com.ydmins.metapay.payment_service.domain.common.TimeBaseEntity;
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+
+@Entity
+public class Payment extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private BigDecimal amount;
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus status;
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod method;
+    private String errorMessage;
+    private String paymentGateway;
+
+    private String userId;
+    private String orderId;
+}

--- a/payment-service/src/main/java/com/ydmins/metapay/payment_service/domain/payment/PaymentMethod.java
+++ b/payment-service/src/main/java/com/ydmins/metapay/payment_service/domain/payment/PaymentMethod.java
@@ -1,0 +1,5 @@
+package com.ydmins.metapay.payment_service.domain.payment;
+
+public enum PaymentMethod {
+    CREDIT_CARD, DEBIT_CARD, BANK_TRANSFER
+}

--- a/payment-service/src/main/java/com/ydmins/metapay/payment_service/domain/payment/PaymentStatus.java
+++ b/payment-service/src/main/java/com/ydmins/metapay/payment_service/domain/payment/PaymentStatus.java
@@ -1,0 +1,5 @@
+package com.ydmins.metapay.payment_service.domain.payment;
+
+public enum PaymentStatus {
+    PENDING, SUCCESSFUL, FAILED, CANCELLED
+}


### PR DESCRIPTION
해당 PR은 결제 서비스의 핵심 도메인 엔티티와 열거형을 추가합니다.

변경사항은 다음과 같습니다.
Entity: 
- TimeBaseEntity : 생성 시간과 수정 시간 필드를 포함하는 추상 엔티티입니다. 감사(auditing) 목적으로 사용됩니다.
- Payment : 결제를 나타내는 도메인 엔티티입니다. TimeBaseEntity를 상속 받고, 금액, 결제상태, 결제방법 등의 정보를 포함합니다.

enum:
- PaymentMtehod : 지원되는 결제 방법을 정의합니다. (예: CREDIT_CARD, DEBIT_CARD, BANK_TRANSFER)
- PaymentStatus : 결제 상태를 지정합니다. (예: PENDING, SUCCESSFUL, FAILED, CANCELLED)

Payment의 도메인은 위의 추가 사항들을 기초로 하며, 향후 PR에서의 핵심 비즈니스 로직을 구현에 필수사항입니다.

이후 계획:
- PaymentRepository 구현
- PaymentService 구현
- PaymentController 구현

엔티티 설계와 열거형 정의를 검토해 주시길 요청드립니다.