### PR TITLE
Feature/payment/add dockerfile

### DIFF
--- a/payment-service/Dockerfile
+++ b/payment-service/Dockerfile
@@ -1,0 +1,7 @@
+# Build Stage
+FROM gradle:7.6.1-jdk17 AS build
+WORKDIR /app
+COPY gradlew build.gradle settings.gradle ./
+COPY gradle ./gradle
+COPY src ./src
+RUN ./gradlew build --no-daemon --exclude-task test

--- a/payment-service/Dockerfile
+++ b/payment-service/Dockerfile
@@ -1,7 +1,23 @@
-# Build Stage
-FROM gradle:7.6.1-jdk17 AS build
+# Base Stage
+FROM gradle:7.6.1-jdk17 AS base
 WORKDIR /app
 COPY gradlew build.gradle settings.gradle ./
 COPY gradle ./gradle
 COPY src ./src
+
+# Build Stage
+FROM base AS build-stage
 RUN ./gradlew build --no-daemon --exclude-task test
+
+# Test Stage
+FROM build-stage AS test-stage
+RUN ./gradlew test --no-daemon
+
+# Runtime Stage
+FROM openjdk:17-jdk-slim AS runtime-stage
+WORKDIR /app
+EXPOSE 8080
+COPY --from=test-stage /app/build/libs/*.jar app.jar
+COPY /src/main/resources/application-mysql.properties /app/config/application-mysql.properties
+ENV SPRING_PROFILES_ACTIVE=mysql
+ENTRYPOINT ["java", "-jar", "app.jar", "--spring.config.additional-location=file:/app/config/application-mysql.properties"]


### PR DESCRIPTION
본 PR에서는 애플리케이션의 빌드, 테스트, 실행을 별도의 단계로 진행하는 멀티 스테이지 Dockerfile을 추가합니다. Dockerfile은 빌드된 후 테스트 진행 후에 애플리케이션이 이미지에 포함되도록 합니다.

변경사항
- Dockerfile : 도커파일은 base-stage, build-stage, test-stage, runtime-stage로 나뉩니다.
-- base-stage : 빌드와 테스트를 위한 공통 준비과정입니다.
-- build-stage : base-stage를 기반으로 프로젝트를 빌드합니다.
-- test-stage : build 완료된 프로젝트의 테스트를 진행합니다.
-- runtime-stage : 테스트까지 완료된 애플리케이션의 이미지를 생성합니다.

특이사항
- runtime-stage : .gitignore에 등록된 application-mysql.properties를 직접 넣어주었습니다.

체크리스트
- [X] 도커파일 생성 후에도 애플리케이션과 테스트 모두 문제없이 실행되는 것을 확인하였습니다.
- [X] 도커 이미지 생성 후 컨테이너 구동시에도 애플리케이션이 정상적으로 실행되는 것을 확인하였습니다.

이후 계획
- 컨테이너를 이용한 클라우드 서버 배포 시도
- ngrinder를 컨테이너 환경에서 구동 후 성능 테스트 시도