### PR TITLE
feature: Health 체크 기능과 테스트 코드 구현

### DIFF
--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok:1.18.22'
 	annotationProcessor 'org.projectlombok:lombok:1.18.22'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/payment-service/src/main/java/com/ydmins/metapay/payment_service/controller/HealthController.java
+++ b/payment-service/src/main/java/com/ydmins/metapay/payment_service/controller/HealthController.java
@@ -1,0 +1,22 @@
+package com.ydmins.metapay.payment_service.controller;
+
+import com.ydmins.metapay.payment_service.service.HealthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/payment/health")
+public class HealthController {
+
+    private final HealthService healthService;
+
+    @GetMapping
+    public Health check(){
+        return healthService.checkHealth();
+    }
+
+}

--- a/payment-service/src/main/java/com/ydmins/metapay/payment_service/service/HealthService.java
+++ b/payment-service/src/main/java/com/ydmins/metapay/payment_service/service/HealthService.java
@@ -1,0 +1,8 @@
+package com.ydmins.metapay.payment_service.service;
+
+import org.springframework.boot.actuate.health.Health;
+
+public interface HealthService {
+
+    Health checkHealth();
+}

--- a/payment-service/src/main/java/com/ydmins/metapay/payment_service/service/HealthServiceImpl.java
+++ b/payment-service/src/main/java/com/ydmins/metapay/payment_service/service/HealthServiceImpl.java
@@ -31,7 +31,9 @@ public class HealthServiceImpl implements HealthService, HealthIndicator {
                 .withDetail(SERVICE, isServiceHealthy)
                 .withDetail(DATABASE, isDatabaseHealthy);
 
-        return (isServiceHealthy && isDatabaseHealthy)
+        boolean isHealthy = isServiceHealthy && isDatabaseHealthy;
+
+        return isHealthy
                 ? healthBuilder.up().build()
                 : healthBuilder.down().build();
     }

--- a/payment-service/src/main/java/com/ydmins/metapay/payment_service/service/HealthServiceImpl.java
+++ b/payment-service/src/main/java/com/ydmins/metapay/payment_service/service/HealthServiceImpl.java
@@ -1,0 +1,52 @@
+package com.ydmins.metapay.payment_service.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Service;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class HealthServiceImpl implements HealthService, HealthIndicator {
+
+    private final DataSource dataSource;
+
+    @Override
+    public Health checkHealth() {
+        Map<String, Object> details = new HashMap<>();
+        details.put("service", checkService());
+        details.put("database", checkDatabase());
+
+        boolean isHealthy = (boolean) details.get("service")
+                && (boolean) details.get("database");
+
+        return isHealthy ?
+                Health.up().withDetails(details).build() :
+                Health.down().withDetails(details).build();
+    }
+
+    private boolean checkService(){
+        return true;
+    }
+
+    private boolean checkDatabase(){
+        try{
+            Connection conn = dataSource.getConnection();
+            return conn.isValid(3000);
+        } catch (SQLException e){
+            return false;
+        }
+    }
+
+
+    @Override
+    public Health health() {
+        return checkHealth();
+    }
+}

--- a/payment-service/src/test/java/com/ydmins/metapay/payment_service/service/HealthServiceImplTest.java
+++ b/payment-service/src/test/java/com/ydmins/metapay/payment_service/service/HealthServiceImplTest.java
@@ -38,7 +38,7 @@ class HealthServiceImplTest {
     }
 
     @Test
-    void checkHealth_allHealty() throws SQLException{
+    void checkHealthAllHealthy() throws SQLException{
         // when
         when(connection.isValid(3000)).thenReturn(true);
         Health health = healthService.checkHealth();
@@ -48,7 +48,7 @@ class HealthServiceImplTest {
     }
 
     @Test
-    void checkHealth_databaseUnhealthy() throws SQLException{
+    void checkHealthDatabaseUnhealthy() throws SQLException{
         // when
         when(connection.isValid(3000)).thenReturn(false);
         Health health = healthService.checkHealth();
@@ -58,7 +58,7 @@ class HealthServiceImplTest {
     }
 
     @Test
-    void checkHealth_databaseException() throws SQLException{
+    void checkHealthDatabaseException() throws SQLException{
         // when
         when(connection.isValid(3000)).thenThrow(new SQLException("Database error"));
         Health health = healthService.checkHealth();
@@ -69,7 +69,7 @@ class HealthServiceImplTest {
 
 
     @Test
-    void health_returnsSameAsCheckHealth() throws SQLException{
+    void healthReturnsSameAsCheckHealth() throws SQLException{
         // when
         when(connection.isValid(3000)).thenReturn(true);
         Health healthFrom_checkHealth = healthService.checkHealth();

--- a/payment-service/src/test/java/com/ydmins/metapay/payment_service/service/HealthServiceImplTest.java
+++ b/payment-service/src/test/java/com/ydmins/metapay/payment_service/service/HealthServiceImplTest.java
@@ -1,0 +1,82 @@
+package com.ydmins.metapay.payment_service.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class HealthServiceImplTest {
+
+    @Mock
+    private DataSource dateSource;
+
+    @Mock
+    private Connection connection;
+
+    private HealthServiceImpl healthService;
+
+    @BeforeEach
+    void setUP() throws SQLException{
+        MockitoAnnotations.openMocks(this);
+        healthService = new HealthServiceImpl(dateSource);
+        when(dateSource.getConnection()).thenReturn(connection);
+    }
+
+    private void assertHealthDetailsMatch(Health health, Status status, boolean serviceHealth, boolean databaseHealth){
+        assertEquals(status, health.getStatus());
+        assertEquals(serviceHealth, health.getDetails().get("service"));
+        assertEquals(databaseHealth, health.getDetails().get("database"));
+    }
+
+    @Test
+    void checkHealth_allHealty() throws SQLException{
+        // when
+        when(connection.isValid(3000)).thenReturn(true);
+        Health health = healthService.checkHealth();
+
+        // then
+        assertHealthDetailsMatch(health, Status.UP, true, true);
+    }
+
+    @Test
+    void checkHealth_databaseUnhealthy() throws SQLException{
+        // when
+        when(connection.isValid(3000)).thenReturn(false);
+        Health health = healthService.checkHealth();
+
+        // then
+        assertHealthDetailsMatch(health, Status.DOWN, true, false);
+    }
+
+    @Test
+    void checkHealth_databaseException() throws SQLException{
+        // when
+        when(connection.isValid(3000)).thenThrow(new SQLException("Database error"));
+        Health health = healthService.checkHealth();
+
+        // then
+        assertHealthDetailsMatch(health, Status.DOWN, true, false);
+    }
+
+
+    @Test
+    void health_returnsSameAsCheckHealth() throws SQLException{
+        // when
+        when(connection.isValid(3000)).thenReturn(true);
+        Health healthFrom_checkHealth = healthService.checkHealth();
+        Health healthFrom_Health = healthService.health();
+
+        // then
+        assertEquals(healthFrom_checkHealth.getStatus(), healthFrom_Health.getStatus());
+        assertEquals(healthFrom_checkHealth.getDetails(), healthFrom_Health.getDetails());
+    }
+}

--- a/payment-service/src/test/java/com/ydmins/metapay/payment_service/service/PaymentServiceImplTest.java
+++ b/payment-service/src/test/java/com/ydmins/metapay/payment_service/service/PaymentServiceImplTest.java
@@ -59,7 +59,8 @@ class PaymentServiceImplTest {
         return paymentCaptor.getValue();
     }
 
-    private void assertPaymentDeatilsMatch(PaymentRequest request, Payment savedPayment, PaymentStatus status, String pg){
+    private void assertPaymentDetailsMatch(PaymentRequest request, Payment savedPayment, PaymentStatus status,
+                                          String pg){
         assertEquals(request.getAmount(), savedPayment.getAmount());
         assertEquals(request.getAmount(), savedPayment.getAmount());
         assertEquals(status, savedPayment.getStatus());
@@ -85,7 +86,7 @@ class PaymentServiceImplTest {
 
         // Captured Payment
         Payment savedPayment = getCapturedPayment();
-        assertPaymentDeatilsMatch(request, savedPayment, PaymentStatus.SUCCESSFUL, "PG");
+        assertPaymentDetailsMatch(request, savedPayment, PaymentStatus.SUCCESSFUL, "PG");
     }
 
     @Test
@@ -104,7 +105,7 @@ class PaymentServiceImplTest {
 
         // Captured Payment
         Payment savedPayment = getCapturedPayment();
-        assertPaymentDeatilsMatch(request, savedPayment, PaymentStatus.FAILED, "PG");
+        assertPaymentDetailsMatch(request, savedPayment, PaymentStatus.FAILED, "PG");
     }
 
     @Test
@@ -122,7 +123,7 @@ class PaymentServiceImplTest {
 
         // Captured Payment
         Payment savedPayment = getCapturedPayment();
-        assertPaymentDeatilsMatch(request, savedPayment, PaymentStatus.FAILED, "PG");
+        assertPaymentDetailsMatch(request, savedPayment, PaymentStatus.FAILED, "PG");
     }
 
     @Test
@@ -142,6 +143,6 @@ class PaymentServiceImplTest {
 
         // Captured Payment
         Payment savedPayment = getCapturedPayment();
-        assertPaymentDeatilsMatch(request, savedPayment, PaymentStatus.SUCCESSFUL, "PG");
+        assertPaymentDetailsMatch(request, savedPayment, PaymentStatus.SUCCESSFUL, "PG");
     }
 }

--- a/payment-service/src/test/java/com/ydmins/metapay/payment_service/service/PaymentServiceImplTest.java
+++ b/payment-service/src/test/java/com/ydmins/metapay/payment_service/service/PaymentServiceImplTest.java
@@ -71,7 +71,7 @@ class PaymentServiceImplTest {
     }
 
     @Test
-    void processPayment_Success() {
+    void processPaymentSuccess() {
         // given
         PaymentRequest request = createPaymentRequest();
         PGResponse pgResponse = createPGResponse(true,"Payment processed successfully");
@@ -90,7 +90,7 @@ class PaymentServiceImplTest {
     }
 
     @Test
-    public void processPayment_Failure(){
+    public void processPaymentFailure(){
         // given
         PaymentRequest request = createPaymentRequest();
         PGResponse pgResponse = createPGResponse(false, "Payment failed");
@@ -109,7 +109,7 @@ class PaymentServiceImplTest {
     }
 
     @Test
-    public void processPayment_PGGatewayServiceException(){
+    public void processPaymentPGServiceException(){
         // given
         PaymentRequest request = createPaymentRequest();
 
@@ -127,7 +127,7 @@ class PaymentServiceImplTest {
     }
 
     @Test
-    public void processPayment_PaymentRepositoryException(){
+    public void processPaymentPaymentRepositoryException(){
         // given
         PaymentRequest request = createPaymentRequest();
         PGResponse pgResponse = createPGResponse(true, "Payment proccssed successfully");


### PR DESCRIPTION
본 PR은 페이서비스의 헬스체크 기능과 테스트 코드 추가를 다룹니다.

도입취지
성능 테스트 및 모니터링을 위해 외부 서비스들을 연결하는 중 본 서비스와 연결이 잘 되었는지 확인하기에 어려움이 있어, 헬스체크 기능을 도입하였습니다.

변경내용
- HealthController : 페이 서비스의 헬스 체크를 위한 엔드포인트 ("/payment/health")를 제공합니다.
- HealthService, HealthServiceIml : HealthIndicator를 이용해 페이 서비스의 헬스 체크 비즈니스 로직을 담당합니다.
- HealthServiceImplTest : 헬스 체크 비즈니스 로직에 대한 테스트 코드입니다.

체크리스트
[x] 모든 테스트 코드가 문제 없이 작동하는 것을 확인하였습니다.
[x] 포스트맨을 이용해 제공하는 엔드포인트가 정상적으로 작동하는 것을 확인하였습니다.

이후 계획
- 클라우드 환경에서의 성능 테스트 및 모니터링 테스트 시도