### PR TITLE
feature : Redis로 캐시 구현

### DIFF
--- a/payment-service/src/main/java/com/ydmins/metapay/payment_service/PaymentServiceApplication.java
+++ b/payment-service/src/main/java/com/ydmins/metapay/payment_service/PaymentServiceApplication.java
@@ -2,10 +2,12 @@ package com.ydmins.metapay.payment_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class PaymentServiceApplication {
 
 	public static void main(String[] args) {

--- a/payment-service/src/main/java/com/ydmins/metapay/payment_service/config/RedisConfig.java
+++ b/payment-service/src/main/java/com/ydmins/metapay/payment_service/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
@@ -28,6 +29,7 @@ public class RedisConfig {
     public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory){
         RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .entryTtl(Duration.ofMinutes(10))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
                 .disableCachingNullValues();
         return RedisCacheManager.builder(redisConnectionFactory)
                 .cacheDefaults(cacheConfiguration)

--- a/payment-service/src/main/java/com/ydmins/metapay/payment_service/domain/payment/dto/GetPaymentResponse.java
+++ b/payment-service/src/main/java/com/ydmins/metapay/payment_service/domain/payment/dto/GetPaymentResponse.java
@@ -23,4 +23,6 @@ public class GetPaymentResponse {
     private String paymentGateway;
     private String userId;
     private String orderId;
+
+    public GetPaymentResponse() {}
 }

--- a/payment-service/src/main/java/com/ydmins/metapay/payment_service/service/PaymentServiceImpl.java
+++ b/payment-service/src/main/java/com/ydmins/metapay/payment_service/service/PaymentServiceImpl.java
@@ -10,6 +10,7 @@ import com.ydmins.metapay.payment_service.exception.*;
 import com.ydmins.metapay.payment_service.service.mapper.PaymentMapper;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import static com.ydmins.metapay.payment_service.common.PaymentMessages.*;
 
@@ -42,6 +43,7 @@ public class PaymentServiceImpl implements PaymentService{
     }
 
     @Override
+    @Cacheable(value="payment", key="#paymentId")
     public GetPaymentResponse getPaymentDetail(Long paymentId) {
         Optional<Payment> optionalPayment = paymentPersistenceService.findPayment(paymentId);
         if(optionalPayment.isPresent()){


### PR DESCRIPTION
본 PR은 feature/payment-service에 이은 PR로 Redis를 이용한 캐싱 구현에 대한 내용을 담고 있습니다.

변경사항
- PaymentServiceAppliction : @EnableCacing 추가
- RedisConfig : 역직렬화 기능 수정
- GetPaymentResponse : 기본생성자 추가
- PaymentServiceImpl : 조회 메서드에 @Cachable 처리

체크리스트
[x] 로컬환경에서 조회 시 Redis에 데이터가 캐시 되는 것을 확인하였습니다.

이후 계획
PaymentService
- 클라우드 환경에 캐시 도입 전 조회 성능 테스트
- AWS EC2로 Redis 인스턴스로 배포
- Redis 클라우드 환경 배포 후 조회 성능 테스트